### PR TITLE
Fixed CI missing version branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - main
+      - '[0-9]+.[0-9]+'
   pull_request: ~
 
 jobs:
@@ -12,6 +14,7 @@ jobs:
     timeout-minutes: 10
 
     strategy:
+      fail-fast: false
       matrix:
         php:
           - '7.3'

--- a/skeleton/ibexa-ee/.github/workflows/ci.yaml
+++ b/skeleton/ibexa-ee/.github/workflows/ci.yaml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - '[0-9]+.[0-9]+'
   pull_request: ~
 
 jobs:
@@ -12,6 +14,7 @@ jobs:
     timeout-minutes: 10
 
     strategy:
+      fail-fast: false
       matrix:
         php:
           - '7.3'

--- a/skeleton/ibexa-oss/.github/workflows/ci.yaml
+++ b/skeleton/ibexa-oss/.github/workflows/ci.yaml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - '[0-9]+.[0-9]+'
   pull_request: ~
 
 jobs:
@@ -12,6 +14,7 @@ jobs:
     timeout-minutes: 10
 
     strategy:
+      fail-fast: false
       matrix:
         php:
           - '7.3'


### PR DESCRIPTION
| Question                                  | Answer
| ----------------------------------------- | ------------------
| **JIRA issue**                            | N/A
| **Type**                                  | improvement
| **Target Ibexa DXP version**              | `v3.3`
| **BC breaks**                             | no

Added missing version branches to `push` declaration for CI.
Added `fail-fast: false` so that tests for different PHP versions are not stopped once one version fails.

#### Checklist:

- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`). 
- [x] Asked for a review (ping `@ibexa/engineering`).
