### PR TITLE
Upgrade Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "symfony/filesystem": "^5.2"
   },
   "require-dev": {
-    "composer/composer": "^1.10.22 || ^2.0.13",
+    "composer/composer": "^1.10.22",
     "phpunit/phpunit": "^9.0",
     "phpstan/phpstan": "^0.12.75",
     "ezsystems/ezplatform-code-style": "^0.4.0"


### PR DESCRIPTION
| Question                                  | Answer
| ----------------------------------------- | ------------------
| **Type**                                  | bug
| **Target Ibexa DXP version**              | `v4.0`
| **BC breaks**                             | no

Upgrade composer minimum requirement due to CVE-2021-29472. A minor to nonexisting issue from our point of view, but we should have clean dependencies in any case. Allows ~both~ composer 1.x ~and 2.x~. This also drops the `@dev`, assuming we don't need it.

#### Checklist:

- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`). 
- [x] Asked for a review (ping `@ibexa/engineering`).
