### PR TITLE
Making Deptrac ruleset a part of default CI pipeline

### DIFF
--- a/skeleton/ibexa-ee/.github/workflows/backend-ci.yaml
+++ b/skeleton/ibexa-ee/.github/workflows/backend-ci.yaml
@@ -42,6 +42,14 @@ jobs:
             -   name: Run code style check
                 run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+    deptrac:
+        name: Deptrac
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v3
+            -   name: Deptrac
+                uses: smoench/deptrac-action@master
+
     tests:
         name: Tests
         runs-on: "ubuntu-22.04"

--- a/skeleton/ibexa-ee/composer.json
+++ b/skeleton/ibexa-ee/composer.json
@@ -23,7 +23,8 @@
     "phpunit/phpunit": "^9",
     "ibexa/code-style": "^1.1",
     "phpstan/phpstan": "^1.2",
-    "phpstan/phpstan-phpunit": "^1.0"
+    "phpstan/phpstan-phpunit": "^1.0",
+    "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
   },
   "autoload": {
     "psr-4": {
@@ -43,13 +44,15 @@
     "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
     "check-cs": "@fix-cs --dry-run",
     "test": "phpunit -c phpunit.xml.dist",
-    "phpstan": "phpstan analyse -c phpstan.neon"
+    "phpstan": "phpstan analyse -c phpstan.neon",
+    "deptrac": "php vendor/bin/deptrac analyse"
   },
   "scripts-descriptions": {
     "fix-cs": "Automatically fixes code style in all files",
     "check-cs": "Run code style checker for all files",
     "test": "Run automatic tests",
-    "phpstan": "Run static code analysis"
+    "phpstan": "Run static code analysis",
+    "deptrac": "Run Deptrac architecture testing"
   },
   "extra": {
     "branch-alias": {

--- a/skeleton/ibexa-ee/deptrac.yaml
+++ b/skeleton/ibexa-ee/deptrac.yaml
@@ -1,0 +1,26 @@
+deptrac:
+    paths:
+        - ./src
+    layers:
+        - name: Bundle
+          collectors:
+              - type: directory
+                value: bundle/.*
+        - name: Contracts
+          collectors:
+              - type: directory
+                value: contracts/.*
+        - name: Library
+          collectors:
+              - type: directory
+                value: lib/.*
+    ruleset:
+        Bundle:
+            - Bundle
+            - Contracts
+            - Library
+        Contracts:
+            - Contracts
+        Library:
+            - Contracts
+            - Library

--- a/skeleton/ibexa-oss/.github/workflows/backend-ci.yaml
+++ b/skeleton/ibexa-oss/.github/workflows/backend-ci.yaml
@@ -33,6 +33,14 @@ jobs:
             -   name: Run code style check
                 run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+    deptrac:
+        name: Deptrac
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v3
+            -   name: Deptrac
+                uses: smoench/deptrac-action@master
+
     tests:
         name: Tests
         runs-on: "ubuntu-22.04"

--- a/skeleton/ibexa-oss/composer.json
+++ b/skeleton/ibexa-oss/composer.json
@@ -20,7 +20,8 @@
     "phpunit/phpunit": "^9.0",
     "ibexa/code-style": "^1.1",
     "phpstan/phpstan": "^1.4",
-    "phpstan/phpstan-phpunit": "^1.0"
+    "phpstan/phpstan-phpunit": "^1.0",
+    "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
   },
   "autoload": {
     "psr-4": {

--- a/skeleton/ibexa-oss/deptrac.yaml
+++ b/skeleton/ibexa-oss/deptrac.yaml
@@ -1,0 +1,26 @@
+deptrac:
+    paths:
+        - ./src
+    layers:
+        - name: Bundle
+          collectors:
+              - type: directory
+                value: bundle/.*
+        - name: Contracts
+          collectors:
+              - type: directory
+                value: contracts/.*
+        - name: Library
+          collectors:
+              - type: directory
+                value: lib/.*
+    ruleset:
+        Bundle:
+            - Bundle
+            - Contracts
+            - Library
+        Contracts:
+            - Contracts
+        Library:
+            - Contracts
+            - Library


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX) |
| **Type**                 | feature <!--bug/improvement-->                      |
| **Target Ibexa version** | n/a                                                 |
| **BC breaks**            | n/a                                                 |

This PR is about making Deptrac (introduced via https://github.com/ibexa/order-management/pull/59) a default job in our CI pipeline.

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
