### PR TITLE
Added missing `composer deptrac` script for OSS versions

### DIFF
--- a/skeleton/ibexa-oss/composer.json
+++ b/skeleton/ibexa-oss/composer.json
@@ -41,13 +41,15 @@
     "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
     "check-cs": "@fix-cs --dry-run",
     "test": "phpunit -c phpunit.xml.dist",
-    "phpstan": "phpstan analyse -c phpstan.neon"
+    "phpstan": "phpstan analyse -c phpstan.neon",
+    "deptrac": "php vendor/bin/deptrac analyse"
   },
   "scripts-descriptions": {
     "fix-cs": "Automatically fixes code style in all files",
     "check-cs": "Run code style checker for all files",
     "test": "Run automatic tests",
-    "phpstan": "Run static code analysis"
+    "phpstan": "Run static code analysis",
+    "deptrac": "Run Deptrac architecture testing"
   },
   "extra": {
     "branch-alias": {


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX) |
| **Type**                 | feature <!--bug/improvement-->                      |
| **Target Ibexa version** | n/a                                                 |
| **BC breaks**            | n/a                                                 |

Followup for https://github.com/ibexa/bundle-generator/pull/15.

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
