### PR TITLE
[Skeletons] Fixed glob pattern in services import of Symfony DI config

### DIFF
--- a/skeleton/extension/src/bundle/Resources/config/services.yaml
+++ b/skeleton/extension/src/bundle/Resources/config/services.yaml
@@ -1,2 +1,2 @@
 imports:
-    - { resource: services/**.yaml }
+    - { resource: services/**/*.yaml }

--- a/skeleton/ibexa-ee/src/bundle/Resources/config/services.yaml
+++ b/skeleton/ibexa-ee/src/bundle/Resources/config/services.yaml
@@ -1,2 +1,2 @@
 imports:
-    - { resource: services/**.yaml }
+    - { resource: services/**/*.yaml }

--- a/skeleton/ibexa-oss/src/bundle/Resources/config/services.yaml
+++ b/skeleton/ibexa-oss/src/bundle/Resources/config/services.yaml
@@ -1,2 +1,2 @@
 imports:
-    - { resource: services/**.yaml }
+    - { resource: services/**/*.yaml }


### PR DESCRIPTION
| Question                 | Answer                                              |
|--------------------------|-----------------------------------------------------|
| **JIRA issue**           | Discovered while working on [IBX-6516](https://issues.ibexa.co/browse/IBX-6516) |
| **Type**                 | bug                      |


Fixed bundle skeletons' glob pattern in services import of Symfony DI configuration.

Seems that:
```yaml
    - { resource: services/**.yaml }
```
doesn't work as expected - sub-directory files are not included.

If we use:
```yaml
    - { resource: services/**/*.yaml }
```
files placed directly in `services` directory and sub-directories are imported.