### PR TITLE
Aligned composer.json indent to use 4 spaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "composer/composer": "^2.1",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "ibexa/code-style": "^1.2",
+        "ibexa/code-style": "~2.0.0",
         "phpstan/phpstan": "^0.12.75",
         "phpunit/phpunit": "^9.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,54 +1,56 @@
 {
-  "name": "ibexa/bundle-generator",
-  "license": "(GPL-2.0-only or proprietary)",
-  "description": "Symfony Bundle generator for Ibexa DXP based projects",
-  "type": "project",
-  "keywords": [
-    "ibexa-dxp"
-  ],
-  "require": {
-    "php": "^7.4 || ^8.0",
-    "symfony/console": "^5.4",
-    "symfony/filesystem": "^5.4"
-  },
-  "require-dev": {
-    "composer/composer": "^2.1",
-    "phpunit/phpunit": "^9.0",
-    "phpstan/phpstan": "^0.12.75",
-    "ibexa/code-style": "^1.2",
-    "ezsystems/ezplatform-code-style": "^2.0",
-    "friendsofphp/php-cs-fixer": "^3.0"
-  },
-  "bin": ["bin/ibexa-bundle-generator"],
-  "autoload": {
-    "psr-4": {
-      "Ibexa\\Bundle\\BundleGenerator\\": "src/bundle",
-      "Ibexa\\Contracts\\BundleGenerator\\": "src/contracts",
-      "Ibexa\\BundleGenerator\\": "src/lib"
+    "name": "ibexa/bundle-generator",
+    "license": "(GPL-2.0-only or proprietary)",
+    "description": "Symfony Bundle generator for Ibexa DXP based projects",
+    "type": "project",
+    "keywords": [
+        "ibexa-dxp"
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "symfony/console": "^5.4",
+        "symfony/filesystem": "^5.4"
+    },
+    "require-dev": {
+        "composer/composer": "^2.1",
+        "phpunit/phpunit": "^9.0",
+        "phpstan/phpstan": "^0.12.75",
+        "ibexa/code-style": "^1.2",
+        "ezsystems/ezplatform-code-style": "^2.0",
+        "friendsofphp/php-cs-fixer": "^3.0"
+    },
+    "bin": [
+        "bin/ibexa-bundle-generator"
+    ],
+    "autoload": {
+        "psr-4": {
+            "Ibexa\\Bundle\\BundleGenerator\\": "src/bundle",
+            "Ibexa\\Contracts\\BundleGenerator\\": "src/contracts",
+            "Ibexa\\BundleGenerator\\": "src/lib"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ibexa\\Tests\\Bundle\\BundleGenerator\\": "tests/bundle",
+            "Ibexa\\Tests\\Integration\\BundleGenerator\\": "tests/integration",
+            "Ibexa\\Tests\\BundleGenerator\\": "tests/lib"
+        }
+    },
+    "scripts": {
+        "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
+        "check-cs": "@fix-cs --dry-run",
+        "test": "phpunit -c phpunit.xml.dist",
+        "phpstan": "phpstan analyse -c phpstan.neon"
+    },
+    "scripts-descriptions": {
+        "fix-cs": "Automatically fixes code style in all files",
+        "check-cs": "Run code style checker for all files",
+        "test": "Run automatic tests",
+        "phpstan": "Run static code analysis"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.0.x-dev"
+        }
     }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Ibexa\\Tests\\Bundle\\BundleGenerator\\": "tests/bundle",
-      "Ibexa\\Tests\\Integration\\BundleGenerator\\": "tests/integration",
-      "Ibexa\\Tests\\BundleGenerator\\": "tests/lib"
-    }
-  },
-  "scripts": {
-    "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
-    "check-cs": "@fix-cs --dry-run",
-    "test": "phpunit -c phpunit.xml.dist",
-    "phpstan": "phpstan analyse -c phpstan.neon"
-  },
-  "scripts-descriptions": {
-    "fix-cs": "Automatically fixes code style in all files",
-    "check-cs": "Run code style checker for all files",
-    "test": "Run automatic tests",
-    "phpstan": "Run static code analysis"
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-main": "1.0.x-dev"
-    }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,10 @@
     },
     "require-dev": {
         "composer/composer": "^2.1",
-        "phpunit/phpunit": "^9.0",
-        "phpstan/phpstan": "^0.12.75",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "ibexa/code-style": "^1.2",
-        "ezsystems/ezplatform-code-style": "^2.0",
-        "friendsofphp/php-cs-fixer": "^3.0"
+        "phpstan/phpstan": "^0.12.75",
+        "phpunit/phpunit": "^9.0"
     },
     "bin": [
         "bin/ibexa-bundle-generator"
@@ -52,5 +51,8 @@
         "branch-alias": {
             "dev-main": "1.0.x-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/skeleton/extension/composer.json
+++ b/skeleton/extension/composer.json
@@ -16,11 +16,11 @@
         "symfony/yaml": "^5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
-        "ibexa/code-style": "^1.1",
+        "ibexa/code-style": "^1.2",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",
+        "phpunit/phpunit": "^9.0",
         "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
     },
     "autoload": {
@@ -55,5 +55,8 @@
         "branch-alias": {
             "dev-main": "4.6.x-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/skeleton/extension/composer.json
+++ b/skeleton/extension/composer.json
@@ -16,7 +16,7 @@
         "symfony/yaml": "^5.4"
     },
     "require-dev": {
-        "ibexa/code-style": "^1.2",
+        "ibexa/code-style": "~2.0.0",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",

--- a/skeleton/extension/composer.json
+++ b/skeleton/extension/composer.json
@@ -53,7 +53,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-main": "4.5.x-dev"
+      "dev-main": "4.6.x-dev"
     }
   }
 }

--- a/skeleton/extension/composer.json
+++ b/skeleton/extension/composer.json
@@ -1,59 +1,59 @@
 {
-  "name": "__VENDOR_NAME__/__PACKAGE_NAME__",
-  "license": "GPL-2.0-only",
-  "type": "ibexa-bundle",
-  "keywords": [
-    "ibexa-dxp"
-  ],
-  "require": {
-    "php": "^7.4 || ^8.0",
-    "ibexa/core": "^4.5",
-    "symfony/config": "^5.4",
-    "symfony/dependency-injection": "^5.4",
-    "symfony/event-dispatcher": "^5.4",
-    "symfony/http-foundation": "^5.4",
-    "symfony/http-kernel": "^5.4",
-    "symfony/yaml": "^5.4"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^9.0",
-    "ibexa/code-style": "^1.1",
-    "phpstan/phpstan": "^1.10",
-    "phpstan/phpstan-phpunit": "^1.3",
-    "phpstan/phpstan-symfony": "^1.3",
-    "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
-  },
-  "autoload": {
-    "psr-4": {
-      "__VENDOR_NAMESPACE__\\Bundle\\__BUNDLE_NAME__\\": "src/bundle/",
-      "__VENDOR_NAMESPACE__\\Contracts\\__BUNDLE_NAME__\\": "src/contracts/",
-      "__VENDOR_NAMESPACE__\\__BUNDLE_NAME__\\": "src/lib/"
+    "name": "__VENDOR_NAME__/__PACKAGE_NAME__",
+    "license": "GPL-2.0-only",
+    "type": "ibexa-bundle",
+    "keywords": [
+        "ibexa-dxp"
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ibexa/core": "^4.5",
+        "symfony/config": "^5.4",
+        "symfony/dependency-injection": "^5.4",
+        "symfony/event-dispatcher": "^5.4",
+        "symfony/http-foundation": "^5.4",
+        "symfony/http-kernel": "^5.4",
+        "symfony/yaml": "^5.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.0",
+        "ibexa/code-style": "^1.1",
+        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpstan/phpstan-symfony": "^1.3",
+        "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "__VENDOR_NAMESPACE__\\Bundle\\__BUNDLE_NAME__\\": "src/bundle/",
+            "__VENDOR_NAMESPACE__\\Contracts\\__BUNDLE_NAME__\\": "src/contracts/",
+            "__VENDOR_NAMESPACE__\\__BUNDLE_NAME__\\": "src/lib/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "__VENDOR_NAMESPACE__\\Tests\\Bundle\\__BUNDLE_NAME__\\": "tests/bundle/",
+            "__VENDOR_NAMESPACE__\\Tests\\Integration\\__BUNDLE_NAME__\\": "tests/integration/",
+            "__VENDOR_NAMESPACE__\\Tests\\__BUNDLE_NAME__\\": "tests/lib/"
+        }
+    },
+    "scripts": {
+        "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
+        "check-cs": "@fix-cs --dry-run",
+        "test": "phpunit -c phpunit.xml.dist",
+        "phpstan": "phpstan analyse -c phpstan.neon",
+        "deptrac": "php vendor/bin/deptrac analyse"
+    },
+    "scripts-descriptions": {
+        "fix-cs": "Automatically fixes code style in all files",
+        "check-cs": "Run code style checker for all files",
+        "test": "Run automatic tests",
+        "phpstan": "Run static code analysis",
+        "deptrac": "Run Deptrac architecture testing"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "4.6.x-dev"
+        }
     }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "__VENDOR_NAMESPACE__\\Tests\\Bundle\\__BUNDLE_NAME__\\": "tests/bundle/",
-      "__VENDOR_NAMESPACE__\\Tests\\Integration\\__BUNDLE_NAME__\\": "tests/integration/",
-      "__VENDOR_NAMESPACE__\\Tests\\__BUNDLE_NAME__\\": "tests/lib/"
-    }
-  },
-  "scripts": {
-    "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
-    "check-cs": "@fix-cs --dry-run",
-    "test": "phpunit -c phpunit.xml.dist",
-    "phpstan": "phpstan analyse -c phpstan.neon",
-    "deptrac": "php vendor/bin/deptrac analyse"
-  },
-  "scripts-descriptions": {
-    "fix-cs": "Automatically fixes code style in all files",
-    "check-cs": "Run code style checker for all files",
-    "test": "Run automatic tests",
-    "phpstan": "Run static code analysis",
-    "deptrac": "Run Deptrac architecture testing"
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-main": "4.6.x-dev"
-    }
-  }
 }

--- a/skeleton/ibexa-ee/composer.json
+++ b/skeleton/ibexa-ee/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "ibexa/behat": "~4.6.x-dev",
-        "ibexa/code-style": "^1.1",
+        "ibexa/code-style": "~2.0.0",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",

--- a/skeleton/ibexa-ee/composer.json
+++ b/skeleton/ibexa-ee/composer.json
@@ -23,12 +23,12 @@
         "symfony/yaml": "^5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
         "ibexa/behat": "~4.6.x-dev",
         "ibexa/code-style": "^1.1",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",
+        "phpunit/phpunit": "^9",
         "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
     },
     "autoload": {
@@ -63,5 +63,8 @@
         "branch-alias": {
             "dev-main": "4.6.x-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/skeleton/ibexa-ee/composer.json
+++ b/skeleton/ibexa-ee/composer.json
@@ -1,64 +1,67 @@
 {
-  "name": "__VENDOR_NAME__/__PACKAGE_NAME__",
-  "license": "proprietary",
-  "type": "ibexa-bundle",
-  "keywords": [
-    "ibexa-dxp"
-  ],
-  "repositories": [
-    { "type": "composer", "url": "https://updates.ibexa.co" }
-  ],
-  "require": {
-    "php": "^7.4 || ^8.0",
-    "ibexa/core": "~4.6.x-dev",
-    "symfony/config": "^5.4",
-    "symfony/dependency-injection": "^5.4",
-    "symfony/event-dispatcher": "^5.4",
-    "symfony/event-dispatcher-contracts": "^2.2",
-    "symfony/http-foundation": "^5.4",
-    "symfony/http-kernel": "^5.4",
-    "symfony/yaml": "^5.4"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^9",
-    "ibexa/behat": "~4.6.x-dev",
-    "ibexa/code-style": "^1.1",
-    "phpstan/phpstan": "^1.10",
-    "phpstan/phpstan-phpunit": "^1.3",
-    "phpstan/phpstan-symfony": "^1.3",
-    "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
-  },
-  "autoload": {
-    "psr-4": {
-      "__VENDOR_NAMESPACE__\\Bundle\\__BUNDLE_NAME__\\": "src/bundle/",
-      "__VENDOR_NAMESPACE__\\Contracts\\__BUNDLE_NAME__\\": "src/contracts/",
-      "__VENDOR_NAMESPACE__\\__BUNDLE_NAME__\\": "src/lib/"
+    "name": "__VENDOR_NAME__/__PACKAGE_NAME__",
+    "license": "proprietary",
+    "type": "ibexa-bundle",
+    "keywords": [
+        "ibexa-dxp"
+    ],
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://updates.ibexa.co"
+        }
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ibexa/core": "~4.6.x-dev",
+        "symfony/config": "^5.4",
+        "symfony/dependency-injection": "^5.4",
+        "symfony/event-dispatcher": "^5.4",
+        "symfony/event-dispatcher-contracts": "^2.2",
+        "symfony/http-foundation": "^5.4",
+        "symfony/http-kernel": "^5.4",
+        "symfony/yaml": "^5.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9",
+        "ibexa/behat": "~4.6.x-dev",
+        "ibexa/code-style": "^1.1",
+        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpstan/phpstan-symfony": "^1.3",
+        "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "__VENDOR_NAMESPACE__\\Bundle\\__BUNDLE_NAME__\\": "src/bundle/",
+            "__VENDOR_NAMESPACE__\\Contracts\\__BUNDLE_NAME__\\": "src/contracts/",
+            "__VENDOR_NAMESPACE__\\__BUNDLE_NAME__\\": "src/lib/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "__VENDOR_NAMESPACE__\\Tests\\Bundle\\__BUNDLE_NAME__\\": "tests/bundle/",
+            "__VENDOR_NAMESPACE__\\Tests\\Integration\\__BUNDLE_NAME__\\": "tests/integration/",
+            "__VENDOR_NAMESPACE__\\Tests\\__BUNDLE_NAME__\\": "tests/lib/"
+        }
+    },
+    "scripts": {
+        "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
+        "check-cs": "@fix-cs --dry-run",
+        "test": "phpunit -c phpunit.xml.dist",
+        "phpstan": "phpstan analyse -c phpstan.neon",
+        "deptrac": "php vendor/bin/deptrac analyse"
+    },
+    "scripts-descriptions": {
+        "fix-cs": "Automatically fixes code style in all files",
+        "check-cs": "Run code style checker for all files",
+        "test": "Run automatic tests",
+        "phpstan": "Run static code analysis",
+        "deptrac": "Run Deptrac architecture testing"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "4.6.x-dev"
+        }
     }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "__VENDOR_NAMESPACE__\\Tests\\Bundle\\__BUNDLE_NAME__\\": "tests/bundle/",
-      "__VENDOR_NAMESPACE__\\Tests\\Integration\\__BUNDLE_NAME__\\": "tests/integration/",
-      "__VENDOR_NAMESPACE__\\Tests\\__BUNDLE_NAME__\\": "tests/lib/"
-    }
-  },
-  "scripts": {
-    "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
-    "check-cs": "@fix-cs --dry-run",
-    "test": "phpunit -c phpunit.xml.dist",
-    "phpstan": "phpstan analyse -c phpstan.neon",
-    "deptrac": "php vendor/bin/deptrac analyse"
-  },
-  "scripts-descriptions": {
-    "fix-cs": "Automatically fixes code style in all files",
-    "check-cs": "Run code style checker for all files",
-    "test": "Run automatic tests",
-    "phpstan": "Run static code analysis",
-    "deptrac": "Run Deptrac architecture testing"
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-main": "4.6.x-dev"
-    }
-  }
 }

--- a/skeleton/ibexa-oss/composer.json
+++ b/skeleton/ibexa-oss/composer.json
@@ -17,12 +17,12 @@
         "symfony/yaml": "^5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
         "ibexa/behat": "~4.6.x-dev",
         "ibexa/code-style": "^1.1",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",
+        "phpunit/phpunit": "^9.0",
         "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
     },
     "autoload": {
@@ -57,5 +57,8 @@
         "branch-alias": {
             "dev-main": "4.6.x-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/skeleton/ibexa-oss/composer.json
+++ b/skeleton/ibexa-oss/composer.json
@@ -1,61 +1,61 @@
 {
-  "name": "__VENDOR_NAME__/__PACKAGE_NAME__",
-  "license": "(GPL-2.0-only or proprietary)",
-  "type": "ibexa-bundle",
-  "keywords": [
-    "ibexa-dxp"
-  ],
-  "require": {
-    "php": "^7.4 || ^8.0",
-    "ibexa/core": "~4.6.x-dev",
-    "symfony/config": "^5.4",
-    "symfony/dependency-injection": "^5.4",
-    "symfony/event-dispatcher": "^5.4",
-    "symfony/event-dispatcher-contracts": "^2.2",
-    "symfony/http-foundation": "^5.4",
-    "symfony/http-kernel": "^5.4",
-    "symfony/yaml": "^5.4"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^9.0",
-    "ibexa/behat": "~4.6.x-dev",
-    "ibexa/code-style": "^1.1",
-    "phpstan/phpstan": "^1.10",
-    "phpstan/phpstan-phpunit": "^1.3",
-    "phpstan/phpstan-symfony": "^1.3",
-    "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
-  },
-  "autoload": {
-    "psr-4": {
-      "__VENDOR_NAMESPACE__\\Bundle\\__BUNDLE_NAME__\\": "src/bundle/",
-      "__VENDOR_NAMESPACE__\\Contracts\\__BUNDLE_NAME__\\": "src/contracts/",
-      "__VENDOR_NAMESPACE__\\__BUNDLE_NAME__\\": "src/lib/"
+    "name": "__VENDOR_NAME__/__PACKAGE_NAME__",
+    "license": "(GPL-2.0-only or proprietary)",
+    "type": "ibexa-bundle",
+    "keywords": [
+        "ibexa-dxp"
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ibexa/core": "~4.6.x-dev",
+        "symfony/config": "^5.4",
+        "symfony/dependency-injection": "^5.4",
+        "symfony/event-dispatcher": "^5.4",
+        "symfony/event-dispatcher-contracts": "^2.2",
+        "symfony/http-foundation": "^5.4",
+        "symfony/http-kernel": "^5.4",
+        "symfony/yaml": "^5.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.0",
+        "ibexa/behat": "~4.6.x-dev",
+        "ibexa/code-style": "^1.1",
+        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpstan/phpstan-symfony": "^1.3",
+        "qossmic/deptrac-shim": "^0.24.0 || ^1.0.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "__VENDOR_NAMESPACE__\\Bundle\\__BUNDLE_NAME__\\": "src/bundle/",
+            "__VENDOR_NAMESPACE__\\Contracts\\__BUNDLE_NAME__\\": "src/contracts/",
+            "__VENDOR_NAMESPACE__\\__BUNDLE_NAME__\\": "src/lib/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "__VENDOR_NAMESPACE__\\Tests\\Bundle\\__BUNDLE_NAME__\\": "tests/bundle/",
+            "__VENDOR_NAMESPACE__\\Tests\\Integration\\__BUNDLE_NAME__\\": "tests/integration/",
+            "__VENDOR_NAMESPACE__\\Tests\\__BUNDLE_NAME__\\": "tests/lib/"
+        }
+    },
+    "scripts": {
+        "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
+        "check-cs": "@fix-cs --dry-run",
+        "test": "phpunit -c phpunit.xml.dist",
+        "phpstan": "phpstan analyse -c phpstan.neon",
+        "deptrac": "php vendor/bin/deptrac analyse"
+    },
+    "scripts-descriptions": {
+        "fix-cs": "Automatically fixes code style in all files",
+        "check-cs": "Run code style checker for all files",
+        "test": "Run automatic tests",
+        "phpstan": "Run static code analysis",
+        "deptrac": "Run Deptrac architecture testing"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "4.6.x-dev"
+        }
     }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "__VENDOR_NAMESPACE__\\Tests\\Bundle\\__BUNDLE_NAME__\\": "tests/bundle/",
-      "__VENDOR_NAMESPACE__\\Tests\\Integration\\__BUNDLE_NAME__\\": "tests/integration/",
-      "__VENDOR_NAMESPACE__\\Tests\\__BUNDLE_NAME__\\": "tests/lib/"
-    }
-  },
-  "scripts": {
-    "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php --show-progress=dots",
-    "check-cs": "@fix-cs --dry-run",
-    "test": "phpunit -c phpunit.xml.dist",
-    "phpstan": "phpstan analyse -c phpstan.neon",
-    "deptrac": "php vendor/bin/deptrac analyse"
-  },
-  "scripts-descriptions": {
-    "fix-cs": "Automatically fixes code style in all files",
-    "check-cs": "Run code style checker for all files",
-    "test": "Run automatic tests",
-    "phpstan": "Run static code analysis",
-    "deptrac": "Run Deptrac architecture testing"
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-main": "4.6.x-dev"
-    }
-  }
 }

--- a/skeleton/ibexa-oss/composer.json
+++ b/skeleton/ibexa-oss/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "ibexa/behat": "~4.6.x-dev",
-        "ibexa/code-style": "^1.1",
+        "ibexa/code-style": "~2.0.0",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-symfony": "^1.3",


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|


#### Description:

Some time ago we fixed all our `composer.json`s to use 4 spaces indent. This PR aligns that for the new packages generated via bundle generator / bundle template. Additionally I've bumped Ibexa Code Style to ~2.0.0 and forced sorting packages.
