### PR TITLE
IBX-11853: Updated bundle-generator skeletons for 6.0 bundles

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -43,7 +43,10 @@ jobs:
         run: composer run-script phpstan
 
       - name: Run code style check
-        run: composer run-script check-cs -- --format=checkstyle | cs2pr
+        shell: bash
+        run: |
+          set -euo pipefail
+          composer run-script check-cs -- --format=checkstyle | cs2pr
 
       - name: Run test suite
         run: composer run-script --timeout=600 test

--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '8.3'
           - '8.4'
           - '8.5'
 

--- a/bin/ibexa-bundle-generator
+++ b/bin/ibexa-bundle-generator
@@ -12,6 +12,6 @@ use Ibexa\BundleGenerator\Command\GenerateBundleCommand;
 use Symfony\Component\Console\Application;
 
 $application = new Application();
-$application->add(new GenerateBundleCommand());
+$application->addCommand(new GenerateBundleCommand());
 $application->setDefaultCommand('generate-bundle', true);
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,9 @@
         "ibexa-dxp"
     ],
     "require": {
-        "php": ">=8.3",
-        "symfony/console": "^5.4",
-        "symfony/filesystem": "^5.4"
+        "php": ">=8.4",
+        "symfony/console": "^8.0",
+        "symfony/filesystem": "^8.0"
     },
     "require-dev": {
         "composer/composer": "^2.1",

--- a/skeleton/extension/.github/workflows/backend-ci.yaml
+++ b/skeleton/extension/.github/workflows/backend-ci.yaml
@@ -31,7 +31,10 @@ jobs:
                     dependency-versions: "highest"
 
             -   name: Run code style check
-                run: composer run-script check-cs -- --format=checkstyle | cs2pr
+                shell: bash
+                run: |
+                    set -euo pipefail
+                    composer run-script check-cs -- --format=checkstyle | cs2pr
 
     deptrac:
         name: Deptrac

--- a/skeleton/extension/composer.json
+++ b/skeleton/extension/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "ibexa/core": "~5.0.x-dev",
+        "ibexa/core": "~6.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/event-dispatcher": "^7.4",
@@ -19,14 +19,14 @@
         "dama/doctrine-test-bundle": "^8.2",
         "deptrac/deptrac": "^3.0",
         "ibexa/code-style": "~2.3.0",
-        "ibexa/phpstan": "~5.0.x-dev",
-        "ibexa/rector": "~5.0.x-dev",
-        "ibexa/test-core": "~5.0.x-dev",
+        "ibexa/phpstan": "~6.0.x-dev",
+        "ibexa/rector": "~6.0.x-dev",
+        "ibexa/test-core": "~6.0.x-dev",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2",
         "phpstan/phpstan-symfony": "^2.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^12.5",
         "symfony/phpunit-bridge": "^7.4"
     },
     "autoload": {
@@ -59,7 +59,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "5.0.x-dev"
+            "dev-main": "6.0.x-dev"
         }
     },
     "config": {

--- a/skeleton/extension/phpunit.integration.xml
+++ b/skeleton/extension/phpunit.integration.xml
@@ -1,16 +1,16 @@
+<?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
          bootstrap="tests/integration/bootstrap.php"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
          failOnWarning="true"
-         verbose="true">
+         cacheDirectory="var/.phpunit.cache">
     <php>
-        <env name="KERNEL_CLASS" value="Ibexa\Tests\Integration\__BUNDLE_NAME__\TestKernel" />
-        <env name="SEARCH_ENGINE" value="legacy" />
-        <env name="DATABASE_URL" value="sqlite://i@i/var/test.db" />
+        <env name="KERNEL_CLASS" value="Ibexa\Tests\Integration\__BUNDLE_NAME__\TestKernel"/>
+        <env name="SEARCH_ENGINE" value="legacy"/>
+        <env name="DATABASE_URL" value="sqlite://i@i/var/test.db"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;verbose=0"/>
-        <ini name="intl.default_locale" value="en_US" />
+        <ini name="intl.default_locale" value="en_US"/>
     </php>
     <testsuites>
         <testsuite name="integration">
@@ -18,9 +18,6 @@
         </testsuite>
     </testsuites>
     <extensions>
-        <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
     </extensions>
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/skeleton/extension/phpunit.xml.dist
+++ b/skeleton/extension/phpunit.xml.dist
@@ -1,14 +1,10 @@
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-        backupGlobals="false"
-        backupStaticAttributes="false"
-        bootstrap="vendor/autoload.php"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        failOnWarning="true"
-        colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         failOnWarning="true"
+         colors="true"
+         cacheDirectory="var/.phpunit.cache">
     <testsuites>
         <testsuite name="bundle">
             <directory>tests/bundle</directory>

--- a/skeleton/ibexa-ee/.github/workflows/backend-ci.yaml
+++ b/skeleton/ibexa-ee/.github/workflows/backend-ci.yaml
@@ -25,7 +25,10 @@ jobs:
                     satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}
 
             -   name: Run code style check
-                run: composer run-script check-cs -- --format=checkstyle | cs2pr
+                shell: bash
+                run: |
+                    set -euo pipefail
+                    composer run-script check-cs -- --format=checkstyle | cs2pr
 
     deptrac:
         name: Deptrac

--- a/skeleton/ibexa-ee/composer.json
+++ b/skeleton/ibexa-ee/composer.json
@@ -15,7 +15,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.3",
-        "ibexa/core": "~5.0.x-dev",
+        "ibexa/core": "~6.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/event-dispatcher": "^7.4",
@@ -26,16 +26,16 @@
     "require-dev": {
         "dama/doctrine-test-bundle": "^8.2",
         "deptrac/deptrac": "^3.0",
-        "ibexa/behat": "~5.0.x-dev",
+        "ibexa/behat": "~6.0.x-dev",
         "ibexa/code-style": "~2.3.0",
-        "ibexa/phpstan": "~5.0.x-dev",
-        "ibexa/rector": "~5.0.x-dev",
-        "ibexa/test-core": "~5.0.x-dev",
+        "ibexa/phpstan": "~6.0.x-dev",
+        "ibexa/rector": "~6.0.x-dev",
+        "ibexa/test-core": "~6.0.x-dev",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2",
         "phpstan/phpstan-symfony": "^2.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^12.5",
         "symfony/phpunit-bridge": "^7.4"
     },
     "autoload": {
@@ -70,7 +70,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "5.0.x-dev"
+            "dev-main": "6.0.x-dev"
         }
     },
     "config": {

--- a/skeleton/ibexa-ee/phpunit.integration.xml
+++ b/skeleton/ibexa-ee/phpunit.integration.xml
@@ -1,16 +1,16 @@
+<?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
          bootstrap="tests/integration/bootstrap.php"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
          failOnWarning="true"
-         verbose="true">
+         cacheDirectory="var/.phpunit.cache">
     <php>
-        <env name="KERNEL_CLASS" value="Ibexa\Tests\Integration\__BUNDLE_NAME__\TestKernel" />
-        <env name="SEARCH_ENGINE" value="legacy" />
-        <env name="DATABASE_URL" value="sqlite://i@i/var/test.db" />
+        <env name="KERNEL_CLASS" value="Ibexa\Tests\Integration\__BUNDLE_NAME__\TestKernel"/>
+        <env name="SEARCH_ENGINE" value="legacy"/>
+        <env name="DATABASE_URL" value="sqlite://i@i/var/test.db"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;verbose=0"/>
-        <ini name="intl.default_locale" value="en_US" />
+        <ini name="intl.default_locale" value="en_US"/>
     </php>
     <testsuites>
         <testsuite name="integration">
@@ -18,9 +18,6 @@
         </testsuite>
     </testsuites>
     <extensions>
-        <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
     </extensions>
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/skeleton/ibexa-ee/phpunit.xml.dist
+++ b/skeleton/ibexa-ee/phpunit.xml.dist
@@ -1,14 +1,10 @@
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-        backupGlobals="false"
-        backupStaticAttributes="false"
-        bootstrap="vendor/autoload.php"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        failOnWarning="true"
-        colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         failOnWarning="true"
+         colors="true"
+         cacheDirectory="var/.phpunit.cache">
     <testsuites>
         <testsuite name="bundle">
             <directory>tests/bundle</directory>

--- a/skeleton/ibexa-oss/.github/workflows/backend-ci.yaml
+++ b/skeleton/ibexa-oss/.github/workflows/backend-ci.yaml
@@ -23,7 +23,10 @@ jobs:
                     gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
 
             -   name: Run code style check
-                run: composer run-script check-cs -- --format=checkstyle | cs2pr
+                shell: bash
+                run: |
+                    set -euo pipefail
+                    composer run-script check-cs -- --format=checkstyle | cs2pr
 
     deptrac:
         name: Deptrac

--- a/skeleton/ibexa-oss/composer.json
+++ b/skeleton/ibexa-oss/composer.json
@@ -9,7 +9,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.3",
-        "ibexa/core": "~5.0.x-dev",
+        "ibexa/core": "~6.0.x-dev",
         "symfony/config": "^7.4",
         "symfony/dependency-injection": "^7.4",
         "symfony/event-dispatcher": "^7.4",
@@ -20,16 +20,16 @@
     "require-dev": {
         "dama/doctrine-test-bundle": "^8.2",
         "deptrac/deptrac": "^3.0",
-        "ibexa/behat": "~5.0.x-dev",
+        "ibexa/behat": "~6.0.x-dev",
         "ibexa/code-style": "~2.3.0",
-        "ibexa/phpstan": "~5.0.x-dev",
-        "ibexa/rector": "~5.0.x-dev",
-        "ibexa/test-core": "~5.0.x-dev",
+        "ibexa/phpstan": "~6.0.x-dev",
+        "ibexa/rector": "~6.0.x-dev",
+        "ibexa/test-core": "~6.0.x-dev",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2",
         "phpstan/phpstan-symfony": "^2.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^12.5",
         "symfony/phpunit-bridge": "^7.4"
     },
     "autoload": {
@@ -64,7 +64,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "5.0.x-dev"
+            "dev-main": "6.0.x-dev"
         }
     },
     "config": {

--- a/skeleton/ibexa-oss/phpunit.integration.xml
+++ b/skeleton/ibexa-oss/phpunit.integration.xml
@@ -1,16 +1,16 @@
+<?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
          bootstrap="tests/integration/bootstrap.php"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
          failOnWarning="true"
-         verbose="true">
+         cacheDirectory="var/.phpunit.cache">
     <php>
-        <env name="KERNEL_CLASS" value="Ibexa\Tests\Integration\__BUNDLE_NAME__\TestKernel" />
-        <env name="SEARCH_ENGINE" value="legacy" />
-        <env name="DATABASE_URL" value="sqlite://i@i/var/test.db" />
+        <env name="KERNEL_CLASS" value="Ibexa\Tests\Integration\__BUNDLE_NAME__\TestKernel"/>
+        <env name="SEARCH_ENGINE" value="legacy"/>
+        <env name="DATABASE_URL" value="sqlite://i@i/var/test.db"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;verbose=0"/>
-        <ini name="intl.default_locale" value="en_US" />
+        <ini name="intl.default_locale" value="en_US"/>
     </php>
     <testsuites>
         <testsuite name="integration">
@@ -18,9 +18,6 @@
         </testsuite>
     </testsuites>
     <extensions>
-        <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
     </extensions>
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>

--- a/skeleton/ibexa-oss/phpunit.xml.dist
+++ b/skeleton/ibexa-oss/phpunit.xml.dist
@@ -1,14 +1,10 @@
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-        backupGlobals="false"
-        backupStaticAttributes="false"
-        bootstrap="vendor/autoload.php"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        failOnWarning="true"
-        colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         failOnWarning="true"
+         colors="true"
+         cacheDirectory="var/.phpunit.cache">
     <testsuites>
         <testsuite name="bundle">
             <directory>tests/bundle</directory>


### PR DESCRIPTION
| :ticket: Issue | IBX-11853 |
|----------------|-----------|

#### Description:

Updates the bundle skeletons and the generator application itself as part of the 6.0 revamp:

- **Skeleton dependencies for 6.0**: all `ibexa/*` constraints and the `dev-main` branch alias bumped from 5.0 to 6.0, PHPUnit bumped from `^9.5` to `^12.5`, in line with current 6.0 bundles (e.g. `ibexa/connector-ai-assistant`).
- **Skeleton PHPUnit configurations** migrated to the PHPUnit 12 schema (removed `convert*`/`verbose`/`beStrictAboutTodoAnnotatedTests` attributes and `<listeners>`, switched the DAMA extension to `<bootstrap>`, added a cache directory).
- **`pipefail` fix for code style CI jobs** (skeletons and this repository): without it, the job result reflected the `cs2pr` exit code, so a failing `check-cs` piped into a succeeding `cs2pr` passed the job.
- **Generator application bumped to Symfony 8**: `Application::add()` (removed in Symfony 8) replaced with `addCommand()`. Symfony 8 requires PHP 8.4, so the application's PHP requirement was raised and PHP 8.3 dropped from this repository's CI matrix. Generated bundles are unaffected (their skeletons still target PHP >= 8.3).

#### For QA:

Generate a bundle with each skeleton and verify the output, e.g.:

```bash
composer install
php bin/ibexa-bundle-generator test-package target-dir --vendor-name=ibexa --vendor-namespace=Ibexa --bundle-name=TestPackage --skeleton-name=ibexa-ee
```

The generated `composer.json` should reference `~6.0.x-dev` packages and PHPUnit 12, with no `__PLACEHOLDER__` leftovers. Requires PHP >= 8.4.
